### PR TITLE
changing the JWT signing key to high-entropy random String

### DIFF
--- a/src/main/java/io/javabrains/springsecurityjwt/util/JwtUtil.java
+++ b/src/main/java/io/javabrains/springsecurityjwt/util/JwtUtil.java
@@ -10,11 +10,12 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.UUID;
 
 @Service
 public class JwtUtil {
 
-    private String SECRET_KEY = "secret";
+    private String SECRET_KEY = UUID.randomUUID().toString();
 
     public String extractUsername(String token) {
         return extractClaim(token, Claims::getSubject);


### PR DESCRIPTION
Setting the JWT signing key to `small-sized` `easily guessable` weak string like **"secret"**  can make it vulnerable to offline brute-force attack using cracking tools like [JohnTheRipper](https://github.com/magnumripper/JohnTheRipper), [hashcat](https://github.com/hashcat/hashcat), 
[c-jwt-cracker](https://github.com/brendan-rius/c-jwt-cracker) [1] 

Therefore, the JWT signing key must be [2]
- at least 128 bits (16 characters long)
- cryptographically produced random string having high entropy

I have set the JWT signing key to a cryptographically secure random string so that if anyone uses your code for developing an application, then attackers won't be able to guess the secret key of the application. 

References: 
[1] [Weak Token Secret, OWASP JWT cheat-sheet](  https://cheatsheetseries.owasp.org/cheatsheets/JSON_Web_Token_Cheat_Sheet_for_Java.html)
[2] [Ensure Cryptographic Keys Have Sufficient Entropy RFC-8725 JSON Web Token Best Current Practices](https://tools.ietf.org/html/rfc8725#section-3.5) 