### PR TITLE
Updated JwtUtils to avoid 403 Forbidden error

### DIFF
--- a/src/main/java/io/javabrains/springsecurityjwt/util/JwtUtil.java
+++ b/src/main/java/io/javabrains/springsecurityjwt/util/JwtUtil.java
@@ -6,6 +6,10 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import java.security.Key;
+import java.security.NoSuchAlgorithmException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -14,7 +18,27 @@ import java.util.function.Function;
 @Service
 public class JwtUtil {
 
-    private String SECRET_KEY = "secret";
+    //Specify your algorithm here
+    private Key SECRET_KEY = generateKey("HmacSHA256");
+
+    public JwtUtil() throws NoSuchAlgorithmException {
+    }
+
+    private Key generateKey(String algorithm) throws NoSuchAlgorithmException {
+        try {
+            // Initialize a KeyGenerator for the specified algorithm
+            KeyGenerator keyGenerator = KeyGenerator.getInstance(algorithm);
+
+            // Generate a random secret key
+            SecretKey secretKey = keyGenerator.generateKey();
+
+            // Cast the SecretKey to the Key interface
+            return (Key) secretKey;
+        } catch (NoSuchAlgorithmException e) {
+            // Handle NoSuchAlgorithmException (e.g., algorithm not available)
+            throw new RuntimeException("Error:" + algorithm + " not available.", e);
+        }
+    }
 
     public String extractUsername(String token) {
         return extractClaim(token, Claims::getSubject);


### PR DESCRIPTION
Here, we create a randomized secret key instead of the default "secret" String used before. This caused 403 errors for later versions of Spring Boot dependencies, often requiring 256 byte secret keys for generating a token. This issue was found after I tried implementing it on a newer version of Spring Boot and its dependencies. I found this under the documentation for signWith: 
![image](https://github.com/koushikkothagal/spring-security-jwt/assets/37676456/3b7ab1a3-4347-44ff-bcdf-4a1651c5e5ba)
